### PR TITLE
Process recoverable/irrecoverable errors well.

### DIFF
--- a/docs/reference/kombu.rst
+++ b/docs/reference/kombu.rst
@@ -29,6 +29,8 @@
 
             .. autoattribute:: default_channel
             .. autoattribute:: connected
+            .. autoattribute:: recoverable_connection_errors
+            .. autoattribute:: recoverable_channel_errors
             .. autoattribute:: connection_errors
             .. autoattribute:: channel_errors
             .. autoattribute:: transport

--- a/docs/reference/kombu.transport.base.rst
+++ b/docs/reference/kombu.transport.base.rst
@@ -33,6 +33,23 @@
 
         .. autoattribute:: client
         .. autoattribute:: default_port
+
+        .. attribute:: recoverable_connection_errors
+
+            Optional list of connection related exceptions that can be
+            recovered from, but where the connection must be closed
+            and re-established first.
+
+            If not defined then all :attr:`connection_errors` and
+            :class:`channel_errors` will be regarded as recoverable,
+            but needing to close the connection first.
+
+        .. attribute:: recoverable_channel_errors
+
+            Optional list of channel related exceptions that can be
+            automatically recovered from without re-establishing the
+            connection.
+
         .. autoattribute:: connection_errors
         .. autoattribute:: channel_errors
 

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -20,7 +20,7 @@ from itertools import count
 
 from . import serialization
 from .entity import Exchange, Queue
-from .exceptions import StdChannelError
+from amqp import RecoverableConnectionError
 from .log import get_logger
 from .messaging import Consumer as _Consumer
 from .utils import uuid
@@ -93,8 +93,7 @@ def maybe_declare(entity, channel=None, retry=False, **retry_policy):
 def _maybe_declare(entity):
     channel = entity.channel
     if not channel.connection:
-        raise StdChannelError("channel disconnected")
-
+        raise RecoverableConnectionError('channel disconnected')
     if entity.can_cache_declaration:
         declared = channel.connection.client.declared_entities
         ident = hash(entity)

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -800,6 +800,8 @@ class Connection(object):
 
     @cached_property
     def recoverable_connection_errors(self):
+        """List of connection related exceptions that can be recovered from,
+        but where the connection must be closed and re-established first."""
         try:
             return self.transport.recoverable_connection_errors
         except AttributeError:
@@ -811,6 +813,8 @@ class Connection(object):
 
     @cached_property
     def recoverable_channel_errors(self):
+        """List of channel related exceptions that can be automatically
+        recovered from without re-establishing the connection."""
         try:
             return self.transport.recoverable_channel_errors
         except AttributeError:

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -448,11 +448,18 @@ class Connection(object):
         """
         def _ensured(*args, **kwargs):
             got_connection = 0
+            conn_errors = self.recoverable_connection_errors
+            chan_errors = self.recoverable_channel_errors
+            has_modern_errors = self.transport.recoverable_connection_errors
             for retries in count(0):  # for infinity
                 try:
                     return fun(*args, **kwargs)
-                except self.recoverable_connection_errors, exc:
-                    if got_connection:
+                except conn_errors as exc:
+                    if got_connection and not has_modern_errors:
+                        # transport can not distinguish between
+                        # recoverable/irrecoverable errors, so we propagate
+                        # the error if it persists after a new connection was
+                        # successfully established.
                         raise
                     if max_retries is not None and retries > max_retries:
                         raise
@@ -474,7 +481,7 @@ class Connection(object):
                     if on_revive:
                         on_revive(new_channel)
                     got_connection += 1
-                except self.recoverable_channel_errors, exc:
+                except chan_errors as exc:
                     if max_retries is not None and retries > max_retries:
                         raise
                     self._debug('ensure channel error: %r', exc, exc_info=1)

--- a/kombu/transport/pyamqp.py
+++ b/kombu/transport/pyamqp.py
@@ -73,6 +73,9 @@ class Transport(base.Transport):
         (StdConnectionError, ) + amqp.Connection.connection_errors
     )
     channel_errors = (StdChannelError, ) + amqp.Connection.channel_errors
+    recoverable_connection_errors = \
+        amqp.Connection.recoverable_connection_errors
+    recoverable_channel_errors = amqp.Connection.recoverable_channel_errors
 
     nb_keep_draining = True
     driver_name = 'py-amqp'


### PR DESCRIPTION
Without this, kombu will give up to reconnect to rabbitmq server if being twice disconnected in a short time.
