### PR TITLE
Use amqp.Connection.connected (Issue celery/py-amqp#22)

### DIFF
--- a/kombu/transport/pyamqp.py
+++ b/kombu/transport/pyamqp.py
@@ -119,6 +119,9 @@ class Transport(base.Transport):
         conn.client = self.client
         return conn
 
+    def verify_connection(self, connection):
+        return connection.connected
+
     def close_connection(self, connection):
         """Close the AMQP broker connection."""
         connection.client = None


### PR DESCRIPTION
There is no this verify_connection method in the default package provided by epel, since when you use Transport.verify_connection(), base.Transport.verify_connection() is got invoked which just "return True" and do nothing else!! But the whole oslo.messaging after juno is using this method to judge one connection's status. This hurt the reconnection logic  pretty badly.

(cherry picked from commit fa4268047b45bc4a7e939b985e4c1cafdbbfdece)
